### PR TITLE
Start Slurm for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,4 +159,4 @@ LABEL org.opencontainers.image.description="Breedbase web server"
 LABEL org.opencontainers.image.documentation="https://solgenomics.github.io/sgn/"
 
 # start services when running container...
-ENTRYPOINT /bin/bash /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -159,10 +159,10 @@ docker-compose -f docker-compose.test.yml run --use-aliases test_breedbase
 
 Testing can be performed while other services deployed using docker-compose for development or production are up, as the services defined in docker-compose.test.yml are started on a separate Docker network.
 
-To run only select tests, list them:
+To run only select tests, list them after the `test_breedbase` service:
 
 ```
-docker-compose -f docker-compose.test.yml run --use-aliases test_breedbase t/unit_fixture t/selenium2
+docker-compose -f docker-compose.test.yml run --use-aliases test_breedbase t/unit_fixture/SGN/genefamily.t
 ```
 
 After testing, stop remaining test (for selenium & postgres):

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,6 +6,7 @@ services:
         - breedbase/breedbase:v0.25
     environment:
       HOME: /root
+      MODE: 'TESTING'
       PGPASSWORD: postgres
       SGN_TEST_SERVER: http://test_breedbase:3010
       SGN_REMOTE_SERVER_ADDR: selenium
@@ -18,8 +19,7 @@ services:
       - ./repos:/home/production/cxgn
       # repos/sgn/sgn_test.conf assumes /home/vagrant
       - ./repos:/home/vagrant/cxgn
-    entrypoint: ["perl", "t/test_fixture.pl", "--carpalways", "-v"]
-    command: ["t/unit", "t/unit_fixture", "t/selenium2"]
+    command: ["t/unit", "t/unit_fixture", "t/unit_mech", "t/selenium2"]
     networks:
       - test-breedbase
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,9 @@ sed -i s/localhost/$HOSTNAME/g /etc/slurm-llnl/slurm.conf
 /etc/init.d/slurmd start
 #/etc/init.d/postgres start
 
+if [ "${MODE}" = 'TESTING' ]; then
+    exec perl t/test_fixture.pl --carpalways -v "${@}"
+fi
 
 # load empty fixture and run any missing patches
 


### PR DESCRIPTION
Slurm wasn't started when tests are run via the [test_breedbase](https://github.com/solgenomics/breedbase_dockerfile/blob/cb4392f756d746088ca462fc4c092e15ba904104/docker-compose.test.yml#L2) service, as it didn't run the entrypoint.sh script. This PR makes the entrypoint sript exec the perl t/test_fixture.pl script when the `MODE` environment variable is set to `TESTING`, and updates the test_breedbase service to use the entrypoint.sh script as its ENTRYPOINT.