### PR TITLE
Fix container image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN cpanm Selenium::Remote::Driver@1.44
 #INSTALL OPENCV IMAGING LIBRARY
 RUN apt-get install -y python3-dev python-pip python3-pip python-numpy libgtk2.0-dev libgtk-3-0 libgtk-3-dev libavcodec-dev libavformat-dev libswscale-dev libhdf5-serial-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libxvidcore-dev libatlas-base-dev gfortran libgdal-dev exiftool libzbar-dev cmake
 RUN pip3 install --upgrade pip
-RUN pip3 install imutils numpy matplotlib pillow statistics PyExifTool pytz pysolar scikit-image packaging pyzbar pandas opencv-python \
+RUN pip3 install grpcio==1.40.0 imutils numpy matplotlib pillow statistics PyExifTool pytz pysolar scikit-image packaging pyzbar pandas opencv-python \
     && pip3 install -U keras-tuner
 
 # copy some tools that don't have a Debian package

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,9 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 RUN apt-get update -y --allow-unauthenticated
 RUN apt-get upgrade -y
 RUN apt-get install build-essential pkg-config apt-utils gnupg2 curl wget -y
-# key for cran-backports (not working though)
+# key for cran-backports
 #
-RUN bash -c "apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF' 1>/key.out   2> /key.err"
+RUN bash -c "apt-key adv --keyserver keyserver.ubuntu.com --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF' 1>/key.out   2> /key.err"
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc |  apt-key add -
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,12 @@ COPY tools/sreformat /usr/local/bin/
 COPY cxgn/sgn/js/install_node.sh /
 RUN bash /install_node.sh
 
+WORKDIR sgn/js
+COPY ./cxgn/sgn/js/package.json .
+RUN npm install
+COPY ./cxgn/sgn/js/ .
+RUN npm run build
+
 COPY slurm.conf /etc/slurm-llnl/slurm.conf
 
 COPY sgn_local.conf /home/production/cxgn/sgn/sgn_local.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN apt-get install libmoosex-runnable-perl -y
 RUN apt-get install libgdbm3 libgdm-dev -y
 RUN apt-get install nodejs -y
 
-RUN cpanm Selenium::Remote::Driver@1.44
+RUN cpanm --force Selenium::Remote::Driver@1.44
 
 #INSTALL OPENCV IMAGING LIBRARY
 RUN apt-get install -y python3-dev python-pip python3-pip python-numpy libgtk2.0-dev libgtk-3-0 libgtk-3-dev libavcodec-dev libavformat-dev libswscale-dev libhdf5-serial-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libxvidcore-dev libatlas-base-dev gfortran libgdal-dev exiftool libzbar-dev cmake

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       cache_from:
-        - breedbase/breedbase:v0.25
+        - breedbase/breedbase:v0.31
     environment:
       HOME: /root
       MODE: 'TESTING'
@@ -25,7 +25,7 @@ services:
       - test-breedbase
 
   selenium:
-    image: selenium/standalone-firefox:3.141.59-20210607
+    image: selenium/standalone-firefox:3.141.59-20210929
     shm_size: '2gb'
     healthcheck:
       test: "curl --silent --head http://localhost:4444 || exit 1"
@@ -33,7 +33,7 @@ services:
       - test-breedbase
 
   breedbase_db:
-    image: postgres:12.7
+    image: postgres:12.8
     environment:
       POSTGRES_PASSWORD: postgres
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     ports:
       - 8080:8080
       - 25:25
-    image: breedbase/breedbase:v0.25
+    image: breedbase/breedbase:v0.31
+    build: .
     depends_on:
       - breedbase_db
     container_name: breedbase_web
@@ -13,7 +14,7 @@ services:
   breedbase_db:
     volumes:
       - dbdata:/var/lib/postgresql/data
-    image: postgres:12.7
+    image: postgres:12.8
     container_name: breedbase_db
     healthcheck:
       test: "pg_isready -U postgres -d $${POSTGRES_DB} || exit 1"


### PR DESCRIPTION
Fix image breakage with debian:stretch due to decommissioned keys.gnupg.net, build failure of latest grpcio, and intermittently-failing-due-to-network-access Selenium::Remote::Driver.

Pre-build sgn/js node modules to reduce startup time & address fatal error in "production" deployment.

Pin newer breedbase, & postgres images.

Update sgn to > 3.10.1 to get test fixes.